### PR TITLE
Alignment problem with casting from int8 to int32 sized objects

### DIFF
--- a/lib/include/embedded_cli.h
+++ b/lib/include/embedded_cli.h
@@ -134,7 +134,7 @@ struct EmbeddedCliConfig {
      * be allocated dynamically. Otherwise this buffer is used and no
      * allocations are made
      */
-    uint8_t *cliBuffer;
+    uint32_t *cliBuffer32;
 
     /**
      * Size of buffer for cli and internal structures.

--- a/tests/EmbeddedCliTest.cpp
+++ b/tests/EmbeddedCliTest.cpp
@@ -24,22 +24,22 @@ TEST_CASE("EmbeddedCli. Static allocation", "[cli]") {
     SECTION("Test creation") {
         INFO("Can't create CLI with small buffer")
         for (size_t size = 1; size < minSize; ++size) {
-            std::vector<uint8_t> data(size);
-            config->cliBuffer = data.data();
+            std::vector<uint32_t> data(size/4+1);
+            config->cliBuffer32 = data.data();
             config->cliBufferSize = size;
             REQUIRE(embeddedCliNew(config) == nullptr);
         }
         INFO("Can create CLI with buffer of minimal size")
-        std::vector<uint8_t> data(minSize);
-        config->cliBuffer = data.data();
+        std::vector<uint32_t> data(minSize/4);
+        config->cliBuffer32 = data.data();
         config->cliBufferSize = minSize;
         EmbeddedCli *cli = embeddedCliNew(config);
 
         REQUIRE(cli != nullptr);
     }
 
-    std::vector<uint8_t> data(minSize);
-    config->cliBuffer = data.data();
+    std::vector<uint32_t> data(minSize/4);
+    config->cliBuffer32 = data.data();
     config->cliBufferSize = minSize;
     EmbeddedCli *cli = embeddedCliNew(config);
 


### PR DESCRIPTION
Hi!  Thanks for the excellent library!  It works like a charm.

However, I did find a nasty problem with the way casting was done.  I changed the way the buffering was implemented so it never has to cast from a smaller to a larger alignment (which is what was causing some *nasty* behavior on an embedded cortext M7.  

The only publicly visible change is that I changed the name of the buffer from cliBuffer to cliBuffer32 just to bring awareness to the change, and the data type is a 32-bit data type, so that if there will be a casting warning, it'll be valid, and show up in the caller's code.
