### PR TITLE
Added config option to enable or disable autocomplete

### DIFF
--- a/lib/include/embedded_cli.h
+++ b/lib/include/embedded_cli.h
@@ -157,6 +157,11 @@ struct EmbeddedCliConfig {
      * Size of buffer for cli and internal structures (in bytes).
      */
     uint16_t cliBufferSize;
+
+    /**
+     * Enable or disable use of autocomplete
+     */
+    bool cliEnableAutoComplete;
 };
 
 /**
@@ -171,6 +176,7 @@ struct EmbeddedCliConfig {
  * -cliBuffer     = NULL (use dynamic allocation)
  * -cliBufferSize = 0
  * -maxBindingCount = 8
+ * -cliEnableAutoComplete = true
  * @return configuration for cli creation
  */
 EmbeddedCliConfig *embeddedCliDefaultConfig(void);

--- a/lib/src/embedded_cli.c
+++ b/lib/src/embedded_cli.c
@@ -154,6 +154,8 @@ struct EmbeddedCliImpl {
      * Flags are defined as CLI_FLAG_*
      */
     uint8_t flags;
+
+  bool enableAutoComplete;
 };
 
 struct AutocompletedCommand {
@@ -373,6 +375,7 @@ EmbeddedCliConfig *embeddedCliDefaultConfig(void) {
     defaultConfig.cliBuffer = NULL;
     defaultConfig.cliBufferSize = 0;
     defaultConfig.maxBindingCount = 8;
+    defaultConfig.cliEnableAutoComplete = true;
     return &defaultConfig;
 }
 
@@ -442,6 +445,7 @@ EmbeddedCli *embeddedCliNew(EmbeddedCliConfig *config) {
     impl->maxBindingsCount = (uint16_t) (config->maxBindingCount + cliInternalBindingCount);
     impl->lastChar = '\0';
     impl->invitation = "> ";
+    impl->enableAutoComplete = config->cliEnableAutoComplete;
 
     initInternalBindings(cli);
 
@@ -935,6 +939,10 @@ static AutocompletedCommand getAutocompletedCommand(EmbeddedCli *cli, const char
 
 static void printLiveAutocompletion(EmbeddedCli *cli) {
     PREPARE_IMPL(cli);
+
+    if (!impl->enableAutoComplete) {
+      return;
+    }
 
     AutocompletedCommand cmd = getAutocompletedCommand(cli, impl->cmdBuffer);
 


### PR DESCRIPTION
Addition of an enableAutoComplete flag in both the config and impl struct.
Early exit from autoComplete function if flag is disabled. 