### PR TITLE
Add condition for clang compile options.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,36 @@ jobs:
           name: windows-example-${{ matrix.arch }}
           path: ${{github.workspace}}/build/examples/win32-example/Release/embedded_cli_win32.exe
 
+  build-mac:
+    runs-on: macos-12
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Create Build Environment
+        run: cmake -E make_directory ${{github.workspace}}/build
+
+      - name: Configure CMake
+        working-directory: ${{github.workspace}}/build
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_SINGLE_HEADER=ON -DBUILD_TESTS=true
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        run: cmake --build . --config $BUILD_TYPE
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C $BUILD_TYPE
+
+      - name: Upload test logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: testing-mac
+          path: ${{github.workspace}}/build/Testing
+
   add-release-assets:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,12 +21,22 @@ target_include_directories(embedded_cli_lib
         PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
         )
 
-
-if (MSVC)
-    # maybe should add more
-    # /WX gives too picky results
-    target_compile_options(embedded_cli_lib PRIVATE /Wall)
-else ()
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    MESSAGE("Enable extra flags for Clang")
+    target_compile_options(embedded_cli_lib PRIVATE
+            -Werror
+            -Wall
+            -Wextra
+            -Wpedantic
+            -Wcast-qual
+            -Wconversion
+            -Wfloat-equal
+            -Wredundant-decls
+            -Wsign-conversion
+            -Wwrite-strings
+            -pedantic-errors)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    MESSAGE("Enable extra flags for GNU")
     target_compile_options(embedded_cli_lib PRIVATE
             -Werror
             -Wall
@@ -43,6 +53,13 @@ else ()
             -Wsign-conversion
             -Wwrite-strings
             -pedantic-errors)
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    MESSAGE("Enable extra flags for MSVC")
+    # maybe should add more
+    # /WX gives too picky results
+    target_compile_options(embedded_cli_lib PRIVATE /Wall)
+else ()
+    MESSAGE(WARNING "Can't enable extra flags for compiler ${CMAKE_CXX_COMPILER_ID}")
 endif ()
 
 add_library(EmbeddedCLI::EmbeddedCLI ALIAS embedded_cli_lib)


### PR DESCRIPTION
It looks like the Apple Clang compiler does not support several flags used.
And build finishes with the following errors:
```
[build] error: unknown warning option '-Wcast-align=strict'; did you mean '-Wcast-align'? [-Werror,-Wunknown-warning-option]
[build] error: unknown warning option '-Wduplicated-branches' [-Werror,-Wunknown-warning-option]
[build] error: unknown warning option '-Wduplicated-cond' [-Werror,-Wunknown-warning-option]
[build] error: unknown warning option '-Wlogical-op'; did you mean '-Wlong-long'? [-Werror,-Wunknown-warning-option]
[build] make[2]: *** [lib/CMakeFiles/embedded_cli_lib.dir/src/embedded_cli.c.o] Error 1
[build] make[1]: *** [lib/CMakeFiles/embedded_cli_lib.dir/all] Error 2
```

On my Mac this fix works correctly. 

Also, printing of variables with
```
include(CMakePrintHelpers)
cmake_print_variables(CMAKE_CXX_COMPILER_ID MSVC)
```
results in the following output:
```
[build] -- CMAKE_CXX_COMPILER_ID="AppleClang" ; MSVC=""
```

Probably it's better to concatenate these flags depending on the compiler ID instead of duplicating their application. It's just an initial idea.