### PR TITLE
make the project to use cxx as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8...3.17)
-project(embedded_cli C)
+project(embedded_cli C CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake-modules")
 
 set(CMAKE_C_STANDARD 11)


### PR DESCRIPTION
I got this error when I tried to build the example:
```
embedded-cli/build$ cmake ..
-- The C compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.10.12", minimum required is "3.0") 
Enable extra flags for GNU
-- Configuring done
CMake Error: Cannot determine link language for target "embedded_cli_linux".
CMake Error: CMake can not determine linker language for target: embedded_cli_linux
-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

The example's source code is cpp file. I think it needs "CXX" as well in the project definition.

I am curious why no one complained about this yet...