### PR TITLE
Added library.json for platformio buid system.

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,17 @@
+{
+    "name": "embedded-cli",
+    "version": "0.1.3",
+    "description" : "Single-header CLI library intended for use in embedded systems.",
+    "keywords": "CLI, Client, Line, Interface, Terminal, Embedded",
+    "license": "MIT",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/funbiscuit/embedded-cli"
+    },
+    "build": {
+        "libArchive": false,
+        "includeDir": "lib/include/",
+        "srcDir": "lib/src/"
+    } 
+}


### PR DESCRIPTION
Hey! I really love embedded-cli, I used in my projects, for which I mostly use [Platformio](https://platformio.org/) as dev environment/build system. To be able to use a lib within a platformio project, you would need a library.json manifest file, see the [docu](https://docs.platformio.org/en/latest/manifests/library-json/index.html). So thats it, the merge request just add that tiny file.