### PR TITLE
Support "Hidden" Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,16 @@ embeddedCliAddBinding(cli, {
         "Get led status",   // Optional help for a command (NULL for no help)
         false,              // flag whether to tokenize arguments (see below)
         nullptr,            // optional pointer to any application context
-        onLed               // binding function 
+        onLed,              // binding function 
+        false               // flag whether to hide the command from help and autocomplete
 });
 embeddedCliAddBinding(cli, {
         "get-adc",
         "Read adc value",
         true,
         nullptr,
-        onAdc
+        onAdc,
+        false
 });
 ```
 Don't forget to create binding functions as well:

--- a/examples/arduino-cli/arduino-cli.ino
+++ b/examples/arduino-cli/arduino-cli.ino
@@ -64,21 +64,24 @@ void setup() {
             "Get led status",
             false,
             nullptr,
-            onLed
+            onLed,
+            false
     });
     embeddedCliAddBinding(cli, {
             "get-adc",
             "Read adc value",
             false,
             nullptr,
-            onAdc
+            onAdc,
+            false
     });
     embeddedCliAddBinding(cli, {
             "hello",
             "Print hello message",
             true,
             (void *) "World",
-            onHello
+            onHello,
+            false
     });
 
     cli->onCommand = onCommand;

--- a/examples/linux-example/main.cpp
+++ b/examples/linux-example/main.cpp
@@ -55,28 +55,40 @@ int main() {
             "Stop CLI and exit",
             false,
             nullptr,
-            onExit
+            onExit,
+            false
     });
     embeddedCliAddBinding(cli, {
             "get-led",
             "Get current led status",
             false,
             nullptr,
-            onLed
+            onLed,
+            false
     });
     embeddedCliAddBinding(cli, {
             "get-adc",
             "Get current adc value",
             false,
             nullptr,
-            onAdc
+            onAdc,
+            false
     });
     embeddedCliAddBinding(cli, {
             "hello",
             "Print hello message",
             true,
             (void *) "World",
-            onHello
+            onHello,
+            false
+    });
+    embeddedCliAddBinding(cli, {
+            "quit",
+            "Stop CLI and exit",
+            false,
+            nullptr,
+            onExit,
+            true
     });
 
     std::cout << "Cli is running. Press 'Esc' to exit\r\n";

--- a/examples/stm32h7-example/Core/Src/cli_binding.c
+++ b/examples/stm32h7-example/Core/Src/cli_binding.c
@@ -34,7 +34,8 @@ void initCliBinding() {
             .help = "Clears the console",
             .tokenizeArgs = true,
             .context = NULL,
-            .binding = onClearCLI
+            .binding = onClearCLI,
+            .hidden = false
     };
 
     // Command binding for the led command
@@ -43,7 +44,8 @@ void initCliBinding() {
             .help = "Get led status",
             .tokenizeArgs = true,
             .context = NULL,
-            .binding = onLed
+            .binding = onLed,
+            .hidden = false
     };
 
     EmbeddedCli *cli = getCliPointer();

--- a/examples/win32-example/main.cpp
+++ b/examples/win32-example/main.cpp
@@ -47,28 +47,40 @@ int main() {
             "Stop CLI and exit",
             false,
             nullptr,
-            onExit
+            onExit,
+            false
     });
     embeddedCliAddBinding(cli, {
             "get-led",
             "Get current led status",
             false,
             nullptr,
-            onLed
+            onLed,
+            false
     });
     embeddedCliAddBinding(cli, {
             "get-adc",
             "Get current adc value",
             false,
             nullptr,
-            onAdc
+            onAdc,
+            false
     });
     embeddedCliAddBinding(cli, {
             "hello",
             "Print hello message",
             true,
             (void *) "World",
-            onHello
+            onHello,
+            false
+    });
+    embeddedCliAddBinding(cli, {
+            "quit",
+            "Stop CLI and exit",
+            false,
+            nullptr,
+            onExit,
+            true
     });
 
     std::cout << "Cli is running. Press 'Esc' to exit\r\n";

--- a/lib/include/embedded_cli.h
+++ b/lib/include/embedded_cli.h
@@ -88,6 +88,15 @@ struct CliCommandBinding {
      * @param context
      */
     void (*binding)(EmbeddedCli *cli, char *args, void *context);
+
+    /**
+     * Allow a command to be hidden.  Hidden commands don't show up in help or autocomplete
+     * This is useful for command synonyms (e.g. supporting both "exit" and "quit") as well
+     * as hiding advanced commands.  Because this bit can be toggled, hidden commands can be
+     * made visible by changing the bit when desired.
+     */
+    bool hidden;
+
 };
 
 struct EmbeddedCli {

--- a/lib/src/embedded_cli.c
+++ b/lib/src/embedded_cli.c
@@ -844,7 +844,8 @@ static void initInternalBindings(EmbeddedCli *cli) {
             "Print list of commands",
             true,
             NULL,
-            onHelp
+            onHelp,
+	    false
     };
     embeddedCliAddBinding(cli, b);
 }
@@ -862,10 +863,12 @@ static void onHelp(EmbeddedCli *cli, char *tokens, void *context) {
     uint16_t tokenCount = embeddedCliGetTokenCount(tokens);
     if (tokenCount == 0) {
         for (int i = 0; i < impl->bindingsCount; ++i) {
-            writeToOutput(cli, " * ");
-            writeToOutput(cli, impl->bindings[i].name);
-            writeToOutput(cli, lineBreak);
-            printBindingHelp(cli, &impl->bindings[i]);
+            if(!impl->bindings[i].hidden) {
+                writeToOutput(cli, " * ");
+                writeToOutput(cli, impl->bindings[i].name);
+                writeToOutput(cli, lineBreak);
+                printBindingHelp(cli, &impl->bindings[i]);
+            }
         }
     } else if (tokenCount == 1) {
         // try find command
@@ -918,6 +921,10 @@ static AutocompletedCommand getAutocompletedCommand(EmbeddedCli *cli, const char
     for (int i = 0; i < impl->bindingsCount; ++i) {
         const char *name = impl->bindings[i].name;
         size_t len = strlen(name);
+
+        // skip the command if it's hidden
+        if (impl->bindings[i].hidden)
+            continue;
 
         // unset autocomplete flag
         UNSET_U8FLAG(impl->bindingsFlags[i], BINDING_FLAG_AUTOCOMPLETE);

--- a/tests/CliWrapper.cpp
+++ b/tests/CliWrapper.cpp
@@ -67,6 +67,7 @@ void CliWrapper::addBinding(const std::string &name,
                 }
                 wrapper->onBoundCommand(cmd);
             },
+            .hidden = false,
     };
 
     if (embeddedCliAddBinding(cli, binding)) {

--- a/tests/cli/BaseTest.cpp
+++ b/tests/cli/BaseTest.cpp
@@ -197,7 +197,8 @@ TEST_CASE("CLI. Base tests", "[cli]") {
                     .help = nullptr,
                     .tokenizeArgs = false,
                     .context = nullptr,
-                    .binding = nullptr
+                    .binding = nullptr,
+                    .hidden = false
             });
 
             cli.sendLine("get led");


### PR DESCRIPTION
This submission adds an additional "hidden" boolean to the command binding structure.  Commands with the "hidden" bit set are not shown in the help menu or provided in autocomplete.

Why have hidden commands?  One answer is synonyms.  Maybe I want to have "quit" as a synonym to exit without taking up space in the help menu.  Another is advanced features:  Maybe I want some expert commands that aren't shown to the user. 
