### PR TITLE
CMakeLists.txt: enable output of compile commands during generation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake-modules")
 
 set(CMAKE_C_STANDARD 11)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 option(BUILD_TESTS "Build and run tests" OFF)
 option(TESTS_COV "Run coverage on tests" OFF)
 option(BUILD_SINGLE_HEADER "Build single-header version" OFF)


### PR DESCRIPTION
CMakeLists.txt: enable output of compile commands during generation.
    
Reference:
https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html
    
Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>