### PR TITLE
example/linux-example: add newline in printf format

### DIFF
--- a/examples/linux-example/main.cpp
+++ b/examples/linux-example/main.cpp
@@ -29,7 +29,7 @@ void onAdc(EmbeddedCli *cli, char *args, void *context);
 int main() {
     // Single character buffer for reading keystrokes
     unsigned char c;
-    
+
     // Structures to save the terminal settings for original settings & raw mode
     struct termios original_stdin;
     struct termios raw_stdin;
@@ -95,15 +95,15 @@ int main() {
 
     // restore terminal settings
     tcsetattr(STDIN_FILENO, TCSANOW, &original_stdin);
-    
+
     return 0;
 }
 
 void onCommand(const std::string &name, char *tokens) {
-    std::cout << "Received command: " << name << "\n";
+    std::cout << "Received command: " << name << "\r\n";
 
     for (int i = 0; i < embeddedCliGetTokenCount(tokens); ++i) {
-        std::cout << "Arg " << i << ": " << embeddedCliGetToken(tokens, i + 1) << "\n";
+        std::cout << "Arg " << i << ": " << embeddedCliGetToken(tokens, i + 1) << "\r\n";
     }
 }
 


### PR DESCRIPTION
example/linux-example: add newline in printf format

before
```sh
➜  /home/mi/xiaomi/embedded-cli git:(dev) ./build/examples/linux-example/embedded_cli_linux
Cli is running. Press 'Esc' to exit
Type "help" for a list of commands
Use backspace and tab to remove chars and autocomplete
> 123 456 789
Received command: 123
                     Arg 0: 456
                               Arg 1: 789
                                         >
>
> abc edf ghi
Received command: abc
                     Arg 0: edf
                               Arg 1: ghi
                                         >
>
> exit
Cli will shutdown now...
➜  /home/mi/xiaomi/embedded-cli git:(dev)
```

after
```sh
➜  /home/mi/xiaomi/embedded-cli git:(dev) ✗ ./build/examples/linux-example/embedded_cli_linux
Cli is running. Press 'Esc' to exit
Type "help" for a list of commands
Use backspace and tab to remove chars and autocomplete
> 123 456 789
Received command: 123
Arg 0: 456
Arg 1: 789
> abc def ghi
Received command: abc
Arg 0: def
Arg 1: ghi
>
>
> exit
Cli will shutdown now...
```

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>