### PR TITLE
feat: add home, end, and delete cursor functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ Terminal is required for correct experience. Following control sequences are res
 * \t moves cursor to the end of autocompleted command
 * Esc[A (key up) and Esc[B (key down) navigates through history
 * Esc[C (key right) and Esc[D (key left) moves the cursor left and right
+* Esc[H (Home) or Esc[1~ / Esc[7~ moves the cursor to the start of the line
+* Esc[F (End) or Esc[4~ / Esc[8~ moves the cursor to the end of the line
+* Esc[3~ (Delete) deletes the character at the cursor position
 
 If you run CLI through a serial port (like on Arduino with its UART-USB converter),
 you can use for example PuTTY (Windows) or XTerm (Linux).

--- a/lib/src/embedded_cli.c
+++ b/lib/src/embedded_cli.c
@@ -760,6 +760,29 @@ static void onEscapedInput(EmbeddedCli *cli, char c) {
             impl->cursorPos++;
             writeToOutput(cli, escSeqCursorLeft);
         }
+
+        // Home
+        if (c == 'H' || (c == '~' && (impl->lastChar == '1' || impl->lastChar == '7'))) {
+            if (impl->cursorPos < impl->cmdSize) {
+                moveCursor(cli, impl->cmdSize - impl->cursorPos, CURSOR_DIRECTION_BACKWARD);
+                impl->cursorPos = impl->cmdSize;
+            }
+        }
+        // End
+        if (c == 'F' || (c == '~' && (impl->lastChar == '4' || impl->lastChar == '8'))) {
+            if (impl->cursorPos > 0) {
+                moveCursor(cli, impl->cursorPos, CURSOR_DIRECTION_FORWARD);
+                impl->cursorPos = 0;
+            }
+        }
+        // Delete
+        if (c == '~' && impl->lastChar == '3' && impl->cursorPos > 0) {
+            size_t insertPos = strlen(impl->cmdBuffer) - impl->cursorPos;
+            memmove(&impl->cmdBuffer[insertPos], &impl->cmdBuffer[insertPos + 1], impl->cursorPos);
+            --impl->cmdSize;
+            --impl->cursorPos;
+            writeToOutput(cli, escSeqDeleteChar);
+        }
     }
 }
 


### PR DESCRIPTION
This commit implements support for the Home, End, and Delete keys to improve command line navigation and editing.

Home Key: Moves the cursor to the beginning of the command line.
End Key: Moves the cursor to the end of the command line.
Delete Key: Removes the character at the current cursor position.

The changes include parsing the corresponding ANSI escape sequences in onEscapedInput within [embedded_cli.c](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).