### PR TITLE
Update github actions dependencies to make CI pass

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Coverage
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: cmake --build . --target coverage_xml
+        run: cmake --build . --target coverage_xml -- VERBOSE=1 GCOVR_ADDITIONAL_ARGS="--gcov-ignore-errors=no_working_dir_found"
 
       - name: Upload test logs
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,7 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: ctest -C $BUILD_TYPE
+        run: ctest -C Release
 
       - name: Upload test logs
         if: ${{ always() }}
@@ -165,11 +165,11 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: cmake --build . --config $BUILD_TYPE
+        run: cmake --build . --config Release
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest -C $BUILD_TYPE
+        run: ctest -C Release
 
       - name: Upload test logs
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Coverage
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: cmake --build . --target coverage_xml -- VERBOSE=1 GCOVR_ADDITIONAL_ARGS="--gcov-ignore-errors=no_working_dir_found"
+        run: cmake --build . --target coverage_xml
 
       - name: Upload test logs
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,11 +165,11 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: cmake --build . --config Release
+        run: cmake --build . --config $BUILD_TYPE
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest -C Release
+        run: ctest -C $BUILD_TYPE
 
       - name: Upload test logs
         if: ${{ always() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,6 +132,7 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build
+        shell: bash
         run: ctest -C $BUILD_TYPE
 
       - name: Upload test logs
@@ -148,7 +149,7 @@ jobs:
           path: ${{github.workspace}}/build/examples/win32-example/Release/embedded_cli_win32.exe
 
   build-mac:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   release:
-    types: [ published ]
+    types: [published]
 
 env:
   BUILD_TYPE: Debug
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -60,21 +60,21 @@ jobs:
 
       - name: Upload test logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: testing-shl-${{ matrix.build_single_header }}
           path: ${{github.workspace}}/build/Testing
 
       - name: Upload coverage
         if: ${{ matrix.build_single_header == 'OFF' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: coverage
           path: ${{github.workspace}}/build/coverage_xml.xml
 
       - name: Upload generated header
         if: ${{ matrix.build_single_header == 'ON' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: single-header
           path: ${{github.workspace}}/lib/shl/embedded_cli.h
@@ -86,23 +86,23 @@ jobs:
           files: ${{ github.workspace }}/build/coverage_xml.xml
 
   build-arduino-example:
-      runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-      steps:
-        - uses: actions/checkout@v3
+    steps:
+      - uses: actions/checkout@v6
 
-        - name: Generate single header lib
-          working-directory: ${{github.workspace}}/lib
-          run: python3 build-shl.py
+      - name: Generate single header lib
+        working-directory: ${{github.workspace}}/lib
+        run: python3 build-shl.py
 
-        - name: Copy single header file to sketch dir
-          run: cp ${{github.workspace}}/lib/shl/embedded_cli.h ${{github.workspace}}/examples/arduino-cli/embedded_cli.h
+      - name: Copy single header file to sketch dir
+        run: cp ${{github.workspace}}/lib/shl/embedded_cli.h ${{github.workspace}}/examples/arduino-cli/embedded_cli.h
 
-        - name: Compile arduino sketch
-          uses: arduino/compile-sketches@v1
-          with:
-            sketch-paths: |
-              - examples/arduino-cli
+      - name: Compile arduino sketch
+        uses: arduino/compile-sketches@v1
+        with:
+          sketch-paths: |
+            - examples/arduino-cli
 
   build-win:
     strategy:
@@ -115,7 +115,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -136,13 +136,13 @@ jobs:
 
       - name: Upload test logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: testing-win-${{ matrix.arch }}
           path: ${{github.workspace}}/build/Testing
 
       - name: Upload windows examples
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: windows-example-${{ matrix.arch }}
           path: ${{github.workspace}}/build/examples/win32-example/Release/embedded_cli_win32.exe
@@ -151,7 +151,7 @@ jobs:
     runs-on: macos-12
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload test logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: testing-mac
           path: ${{github.workspace}}/build/Testing
@@ -180,9 +180,9 @@ jobs:
   add-release-assets:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    needs: [ build ]
+    needs: [build]
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v7
         with:
           path: artifacts
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   create-release:
@@ -14,7 +14,7 @@ jobs:
         id: version
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
           name: embedded-cli ${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - "*"
+      - '*'
 
 jobs:
   create-release:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ if (${BUILD_TESTS})
                 NAME coverage_xml
                 EXECUTABLE ctest
                 DEPENDENCIES embedded_cli_tests
-                EXCLUDE "tests/*")
+                EXCLUDE "tests/*"
+                         "deps/catch2/*"
+                         "build/deps/*")
     endif ()
 endif ()

--- a/cmake-modules/CodeCoverage.cmake
+++ b/cmake-modules/CodeCoverage.cmake
@@ -334,6 +334,7 @@ function(setup_target_for_coverage_gcovr_xml)
 
             # Running gcovr
             COMMAND ${GCOVR_PATH} --xml
+            --gcov-ignore-errors=no_working_dir_found
             -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
             --object-directory=${PROJECT_BINARY_DIR}
             -o ${Coverage_NAME}.xml
@@ -410,6 +411,7 @@ function(setup_target_for_coverage_gcovr_html)
 
             # Running gcovr
             COMMAND ${GCOVR_PATH} --html --html-details
+            --gcov-ignore-errors=no_working_dir_found
             -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
             --object-directory=${PROJECT_BINARY_DIR}
             -o ${Coverage_NAME}/index.html


### PR DESCRIPTION
This PR introduces some of the must-have changes to deal with dependencies that had been deprecated for some time.
On top of that there are some fixes and hacks around the actions to make the CI pass as there were some unexpected
errors once dependencies were resolved.

In general the following minor adjustments were made:
- minor formatting changes were applied to **.ci.yaml**
- **CodeCoverage.cmake** was changed to fix "gcovr no_working_dir_found" error
- CMakeLists.txt was updated to exclude some folders from analysis due to reported errors

Some of the proposed fixes could probably done differently but I wanted to introduce as minimal changes as possible
without rewriting any logic that was previously set-up.
I'm open to any discussion/suggestions if something should be changed.