### PR TITLE
feat: add home, end, and delete cursor functionality

### DIFF
--- a/lib/src/embedded_cli.c
+++ b/lib/src/embedded_cli.c
@@ -760,6 +760,29 @@ static void onEscapedInput(EmbeddedCli *cli, char c) {
             impl->cursorPos++;
             writeToOutput(cli, escSeqCursorLeft);
         }
+
+        // Home
+        if (c == 'H' || (c == '~' && (impl->lastChar == '1' || impl->lastChar == '7'))) {
+            if (impl->cursorPos < impl->cmdSize) {
+                moveCursor(cli, impl->cmdSize - impl->cursorPos, CURSOR_DIRECTION_BACKWARD);
+                impl->cursorPos = impl->cmdSize;
+            }
+        }
+        // End
+        if (c == 'F' || (c == '~' && (impl->lastChar == '4' || impl->lastChar == '8'))) {
+            if (impl->cursorPos > 0) {
+                moveCursor(cli, impl->cursorPos, CURSOR_DIRECTION_FORWARD);
+                impl->cursorPos = 0;
+            }
+        }
+        // Delete
+        if (c == '~' && impl->lastChar == '3' && impl->cursorPos != 0) {
+            size_t insertPos = strlen(impl->cmdBuffer) - impl->cursorPos;
+            memmove(&impl->cmdBuffer[insertPos], &impl->cmdBuffer[insertPos + 1], impl->cursorPos);
+            --impl->cmdSize;
+            --impl->cursorPos;
+            writeToOutput(cli, escSeqDeleteChar);
+        }
     }
 }
 

--- a/tests/cli/BaseTest.cpp
+++ b/tests/cli/BaseTest.cpp
@@ -157,6 +157,89 @@ TEST_CASE("CLI. Base tests", "[cli]") {
         REQUIRE(displayed.cursorColumn == 7);
     }
 
+    SECTION("Move cursor to start") {
+        cli.send(" both\x1B[Hget");
+        cli.process();
+        auto displayed = cli.getDisplay();
+        REQUIRE(displayed.lines.size() == 1);
+        REQUIRE(displayed.lines[0] == "> get both");
+        REQUIRE(displayed.cursorColumn == 5);
+    }
+
+    SECTION("Move cursor to start with 1~ alternative sequence") {
+        cli.send(" both\x1B[1~get");
+        cli.process();
+        auto displayed = cli.getDisplay();
+        REQUIRE(displayed.lines.size() == 1);
+        REQUIRE(displayed.lines[0] == "> get both");
+        REQUIRE(displayed.cursorColumn == 5);
+    }
+
+    SECTION("Move cursor to start with 7~ alternative sequence") {
+        cli.send(" both\x1B[7~get");
+        cli.process();
+        auto displayed = cli.getDisplay();
+        REQUIRE(displayed.lines.size() == 1);
+        REQUIRE(displayed.lines[0] == "> get both");
+        REQUIRE(displayed.cursorColumn == 5);
+    }
+
+    SECTION("Move cursor to start then end") {
+        cli.send("both\x1B[Hget \x1B[F");
+        cli.process();
+        auto displayed = cli.getDisplay();
+        REQUIRE(displayed.lines.size() == 1);
+        REQUIRE(displayed.lines[0] == "> get both");
+        REQUIRE(displayed.cursorColumn == 10);
+    }
+
+    SECTION("Move cursor to start then end with 4~ alternative sequence") {
+        cli.send("both\x1B[Hget \x1B[4~");
+        cli.process();
+        auto displayed = cli.getDisplay();
+        REQUIRE(displayed.lines.size() == 1);
+        REQUIRE(displayed.lines[0] == "> get both");
+        REQUIRE(displayed.cursorColumn == 10);
+    }
+
+
+    SECTION("Move cursor to start then end with 8~ alternative sequence") {
+        cli.send("both\x1B[Hget \x1B[8~");
+        cli.process();
+        auto displayed = cli.getDisplay();
+        REQUIRE(displayed.lines.size() == 1);
+        REQUIRE(displayed.lines[0] == "> get both");
+        REQUIRE(displayed.cursorColumn == 10);
+    }
+
+    SECTION("Move cursor back and perform Delete") {
+        cli.send("get baoth\x1B[D\x1B[D\x1B[D\x1B\x1B[D\x1B[3~");
+        cli.process();
+        auto displayed = cli.getDisplay();
+        REQUIRE(displayed.lines.size() == 1);
+        REQUIRE(displayed.lines[0] == "> get both");
+        REQUIRE(displayed.cursorColumn == 7);
+    }
+
+    SECTION("Delete at end of section") {
+        cli.sendLine("set example\x1B[3~");
+        cli.process();
+
+        auto lines = cli.getDisplay().lines;
+
+        REQUIRE(lines[0] == "> set example");
+
+    }
+
+    SECTION("Delete at start of line should work") {
+        cli.sendLine("nset\x1B[D\x1B[D\x1B[D\x1B[D\x1B[3~");
+        cli.process();
+
+        auto lines = cli.getDisplay().lines;
+
+        REQUIRE(lines[0] == "> set");
+    }
+
     SECTION("Command that is too long") {
         size_t cmdMax = embeddedCliDefaultConfig()->cmdBufferSize;
         std::string cmdMaxTest = std::string(cmdMax/2, 'x');


### PR DESCRIPTION
This is a continuation of the pull request @gary7530 initially submitted, but did not complete the merge that @funbiscuit requested.

@gary7530's original pull request:

> This commit implements support for the Home, End, and Delete keys to improve command-line navigation and editing.
> 
> Home Key: Moves the cursor to the beginning of the command line.
> End Key: Moves the cursor to the end of the command line.
> Delete Key: Removes the character at the current cursor position.
> 
> The changes include parsing the corresponding ANSI escape sequences in onEscapedInput within embedded_cli.c.

Please let me know if any additional changes are required. 